### PR TITLE
Fix links in index.md

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,10 +2,10 @@
 
 <h1>An open, collaborative, <i>frictionless</i>, automated machine learning environment.</h1>
 
-<p><i class="fa fa-globe fa-fw fa-lg"></i> <a href="www.openml.org/d" target="_blank">Data sets</a> automatically analyzed, annotated, and organized online</p>
-<p><i class="fa fa-cogs fa-fw fa-lg"></i> <a href="www.openml.org/f" target="_blank">Machine learning pipelines</a> automatically shared from many libraries.</p>
-<p><i class="fa fa-code fa-fw fa-lg"></i> <a href="API-index">Extensive APIs</a> to integrate OpenML into your own tools and scripts</p>
-<p><i class="fa fa-flask fa-fw fa-lg"></i> <a href="www.openml.org/r" target="_blank">Reproducible results</a> (e.g. models, evaluations) for easy comparison and reuse</p>
+<p><i class="fa fa-globe fa-fw fa-lg"></i> <a href="https://www.openml.org/d" target="_blank">Data sets</a> automatically analyzed, annotated, and organized online</p>
+<p><i class="fa fa-cogs fa-fw fa-lg"></i> <a href="https://www.openml.org/f" target="_blank">Machine learning pipelines</a> automatically shared from many libraries.</p>
+<p><i class="fa fa-code fa-fw fa-lg"></i> <a href="APIs">Extensive APIs</a> to integrate OpenML into your own tools and scripts</p>
+<p><i class="fa fa-flask fa-fw fa-lg"></i> <a href="https://www.openml.org/r" target="_blank">Reproducible results</a> (e.g. models, evaluations) for easy comparison and reuse</p>
 <p><i class="fa fa-users fa-fw fa-lg"></i> Collaborate in real time, right from your existing tools</p>
 <p><i class="fa fa-graduation-cap fa-fw fa-lg"></i> Make your work more visible, reusable, and easily citable</p>
 <p><i class="fa fa-bolt fa-fw fa-lg"></i> Open source tools to automate experimentation and model building</p>


### PR DESCRIPTION
This one adds a few `https` which prevent github from linking to the real website. Whether the API link is now correct is something that I cannot check, but it definitely didn't work before.