### PR TITLE
Fix a few links in Contributing.md

### DIFF
--- a/docs/docs/Contributing.md
+++ b/docs/docs/Contributing.md
@@ -16,7 +16,7 @@ We are currently looking for help with:
  * Frontend / UX / Design of the website
  * Backend / API
  * Outreach / making OpenML better known (especially in non-ML-communities, where people have data but no analysis experise)
- * Helping with the interfaces ([Python](https://www.openml.org/#python), [WEKA](https://www.openml.org/#WEKA), [MOA](https://www.openml.org/#plugin_moa), [RapidMiner](https://www.openml.org/#plugin_rm), [Java](https://www.openml.org/#java), [R](https://www.openml.org/#r); find the links to GitHub repos [here](https://github.com/openml/OpenML/wiki))
+ * Helping with the interfaces ([Python](Python-start), [WEKA](https://www.openml.org/#WEKA), [MOA](https://www.openml.org/#plugin_moa), [RapidMiner](https://www.openml.org/#plugin_rm), [Java](Java-guide), [R](R-guide); find the links to GitHub repos [here](https://github.com/openml/OpenML/wiki))
  * Helping with documenting the interfaces or the API
  * What could we do better to get new users started? Help us to figure out what is difficult to understand about OpenML. If you *are* a new user, you are the perfect person for this!
 


### PR DESCRIPTION
They should now point to the starting points of the actual API connectors. However, I don't know where the tool links should point to.