### PR TITLE
Updated broken links api docs

### DIFF
--- a/docs/site/APIs/index.html
+++ b/docs/site/APIs/index.html
@@ -1178,8 +1178,8 @@
 <h2 id="rest"><img alt="icon" src="../img/rest.png" /> REST<a class="headerlink" href="#rest" title="Permanent link">&para;</a></h2>
 <p>The REST API allows you to talk directly to the OpenML server from any programming environment.</p>
 <ul>
-<li><a href="../Rest-tutorial">REST Tutorial</a></li>
-<li><a href="../Rest-API">REST API Reference</a></li>
+<li><a href="../REST-tutorial">REST Tutorial</a></li>
+<li><a href="../REST-API">REST API Reference</a></li>
 </ul>
 <h2 id="python"><img alt="icon" src="../img/python.png" /> Python<a class="headerlink" href="#python" title="Permanent link">&para;</a></h2>
 <p>Download datasets into Python scripts, build models using Python machine learning libraries (e.g., <i>scikit-learn</i>), and share the results online, all in a few lines of code.</p>
@@ -1201,13 +1201,13 @@
 <p>If you are building machine learning systems in Java, there is also an API for that.</p>
 <ul>
 <li><a href="../Java-guide">Java Tutorial</a></li>
-<li><a href="../Java-API">Java API Reference</a></li>
+<li><a href="https://openml.github.io/java/">Java API Reference</a></li>
 </ul>
 <h2 id="net-c"><img alt="icon" src="../img/c++.png" /> .NET (C#)<a class="headerlink" href="#net-c" title="Permanent link">&para;</a></h2>
 <p>The .NET library is under development, but already contains most of the functions available.</p>
 <ul>
-<li><a href="../.NET_API">.NET Tutorial</a></li>
-<li><a href="../&quot;https://github.com/openml/openml-dotnet">GitHub repo</a></li>
+<li><a href="../.Net-API">.NET Tutorial</a></li>
+<li><a href="https://github.com/openml/openml-dotnet">GitHub repo</a></li>
 </ul>
 <h2 id="easy-authentication">Easy authentication<a class="headerlink" href="#easy-authentication" title="Permanent link">&para;</a></h2>
 <p>In the interest of open science, we allow you to freely download all public resources, also through the APIs (rate limits apply when necessary).


### PR DESCRIPTION
See issues #670 and #662. I am not entirely sure about the Java API reference, but I assumed it is supposed to link to https://openml.github.io/java/. 