### PR TITLE
Data edit api

### DIFF
--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -237,65 +237,80 @@ class Api_data extends MY_Api_Model {
     $this->xmlContents('data', $this->version, array('datasets' => $datasets));
   }
 
-   private function data_edit() {
-    // Get columns to be update from post data
+   private function data_edit() {  
+    // get data id
     $data_id = $this->input->post('data_id');
-    $description = $this->input->post('description');
-    $creator =  $this->input->post('creator');
-    $collection_date =  $this->input->post('collection_date');
-    $language = $this->input->post('language');
-    $citation = $this->input->post('citation');
-    $original_data_url = $this->input->post('original_data_url');
-    $paper_url = $this->input->post('paper_url');
+    // get edit parameters as xml
+    $xsdFile = xsd('openml.data.edit', $this->controller, $this->version);
+
+    if($this->input->post('edit_parameters')) {
+      // get fields from string upload
+      $edit_parameters = $this->input->post('edit_parameters', false);
+      if(validateXml($edit_parameters, $xsdFile, $xmlErrors, false ) == false) {
+        $this->returnError(1060, $this->version, $this->openmlGeneralErrorCode, $xmlErrors);
+        return;
+      }
+      $xml = simplexml_load_string( $edit_parameters );
+    } elseif (isset($_FILES['edit_parameters'])) {
+      $uploadError = '';
+      $xmlErrors = '';
+      if (check_uploaded_file($_FILES['edit_parameters'], false, $uploadError) == false) {
+        $this->returnError(1061, $this->version, $this->openmlGeneralErrorCode, $uploadError);
+      }
+      // get fields from file upload
+      $edit_parameters = $_FILES['edit_parameters'];
+
+      if (validateXml($edit_parameters['tmp_name'], $xsdFile, $xmlErrors) == false) {
+        $this->returnError(1060, $this->version, $this->openmlGeneralErrorCode, $xmlErrors);
+        return;
+      }
+      $xml = simplexml_load_file($edit_parameters['tmp_name']);
+    } else {
+      $this->returnError(1061, $this->version);
+      return;
+    }
+
+    // create an array of update fields for the update
+    $update_fields = array();
+    foreach($xml->children('oml', true) as $input) {
+      // iterate over all fields, does not check for legal fields, as it wont match the xsd.  
+        $name = $input->getName() . '';
+        $update_fields[$name] = $input . '';
+      }
 
     // If data id is not given
     if( $data_id == false ) {
-      $this->returnError( 110, $this->version );
+      $this->returnError( 1062, $this->version );
       return;}
-
     // If dataset does not exist
     $dataset = $this->Dataset->getById( $data_id );
     if( $dataset == false ) {
-      $this->returnError( 111, $this->version );
+      $this->returnError( 1063, $this->version );
       return;
     }
 
     // If all the fields are false, there is nothing to update, return error 
-
-    if( $description == false && $creator == false && $collection_date == false && $language == false && $citation == false
-    && $original_data_url == false && $paper_url == false ) {
-      $this->returnError( 1055, $this->version );
+    if(!$update_fields) {
+      $this->returnError( 1064, $this->version );
       return;
     }
-
     // check if user owns dataset
     if($dataset->uploader != $this->user_id and !$this->user_has_admin_rights) {
-      $this->returnError( 353, $this->version );
+      $this->returnError( 1065, $this->version );
       return;
     }
 
-    // Combine all possible updates 
-    $update_description = $description == false ? '': 'description = "'. $description. '"';
-    $update_creator = $creator == false ? '': ' creator = "'. $creator. '" ';
-    $update_collection_date = $collection_date == false ? '': 'collection_date = "'. $collection_date. '" ';
-    $update_language = $language == false ? '': 'language = "'. $language. '" ';
-    $update_citation = $citation == false ? '': 'citation = "'. $citation. '" ';
-    $update_original_data_url = $original_data_url == false ? '': 'original_data_url = "'. $original_data_url. '" ';
-    $update_paper_url = $paper_url == false ? '': 'paper_url = "'. $paper_url. '" ';
-
-    // use , to separate update columns 
-    $update_total = implode(",", array_filter([$update_description, $update_creator, $update_collection_date, 
-      $update_language, $update_citation, $update_original_data_url, $update_paper_url])) ;
-
-    // where data id
-    $where_data = 'where did='. $data_id;
-
-    $this->Dataset->query('update dataset set '. $update_total . $where_data);
-   
-    // Return edited dataset, for user to verify changes    
-    $this->xmlContents( 'data-get', $this->version, $dataset );
-
+    $update_result = $this->Dataset->update($data_id, $update_fields);
+    // If result returns error    
+    if( $update_result == false ) {
+      $this->returnError( 1066, $this->version );
+      return;
     }
+
+    // Return data id, for user to verify changes    
+    $this->xmlContents( 'data-edit', $this->version, array( 'dataset' => $dataset ) );
+    }
+
 
   private function data($data_id) {
     if( $data_id == false ) {

--- a/openml_OS/views/pages/api_new/v1/xml/data-edit.tpl.php
+++ b/openml_OS/views/pages/api_new/v1/xml/data-edit.tpl.php
@@ -1,0 +1,3 @@
+<oml:data_edit xmlns:oml="http://openml.org/openml">
+    <oml:id><?php echo $dataset->did; ?></oml:id>
+</oml:data_edit>

--- a/openml_OS/views/pages/api_new/v1/xml/pre.php
+++ b/openml_OS/views/pages/api_new/v1/xml/pre.php
@@ -509,4 +509,8 @@ $this->apiErrors[1052] = 'Could not find study';
 $this->apiErrors[1053] = 'Study not owned by you';
 $this->apiErrors[1054] = 'Problem inserting in database';
 
+
+//openml.data.edit
+$this->apiErrors[1055] = 'Please provide atleast one field among description, creator, collection_date, language, citation, original_data_url or paper_url to edit. ';
+
 ?>

--- a/openml_OS/views/pages/api_new/v1/xml/pre.php
+++ b/openml_OS/views/pages/api_new/v1/xml/pre.php
@@ -511,6 +511,13 @@ $this->apiErrors[1054] = 'Problem inserting in database';
 
 
 //openml.data.edit
-$this->apiErrors[1055] = 'Please provide atleast one field among description, creator, collection_date, language, citation, original_data_url or paper_url to edit. ';
+//openml.data.edit
+$this->apiErrors[1060] = 'Problem validating edit_parameters xml';
+$this->apiErrors[1061] = 'Please provide edit_parameters xml';
+$this->apiErrors[1062] = 'Data ID is required';
+$this->apiErrors[1063] = 'Unknown dataset';
+$this->apiErrors[1064] = 'Please provide atleast one field among description, creator, contributor, collection_date, language, citation, original_data_url or paper_url to edit. ';
+$this->apiErrors[1065] = 'Dataset is not owned by you';
+$this->apiErrors[1066] = 'Dataset update failed';
 
 ?>

--- a/openml_OS/views/pages/api_new/v1/xsd/openml.data.edit.xsd
+++ b/openml_OS/views/pages/api_new/v1/xsd/openml.data.edit.xsd
@@ -1,0 +1,86 @@
+<!-- Schema for dataset edit parameters. -->
+
+<xs:schema targetNamespace="http://openml.org/openml"
+    xmlns:oml="http://openml.org/openml"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified">
+<xs:element name="data_edit_parameters" type="oml:data_edit_parameters"/>
+<xs:complexType name="data_edit_parameters">
+  <xs:sequence>
+    <!-- dublin core -->
+    <xs:element name="description" minOccurs="0" type="oml:basic_latin16384"/>  <!-- Description of the dataset, given by the user who uploaded it. -->
+    <xs:element name="creator" minOccurs="0" maxOccurs="unbounded" type="oml:basic_latin128"/> <!-- The person who created the dataset -->
+    <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded" type="oml:basic_latin128"/> <!-- People who contributed to the current version of the datadat (e.g. reformatting) -->
+    <xs:element name="collection_date" minOccurs="0" type="oml:basic_latin128"/>  <!-- The date the data was originally collected, given by the uploader -->
+    <xs:element name="language" minOccurs="0" type="oml:casual_string128"/> <!-- Language in which the data is represented. Starts with 1 upper case letter, rest lower case, e.g. 'English' -->
+    <!-- other -->
+    <xs:element name="citation" minOccurs="0" type="oml:basic_latin1024"/> <!-- Reference(s) that should be cited when building on this data -->
+    <xs:element name="original_data_url" minOccurs="0" type="xs:anyURI"/> <!-- For derived data, the url to the original dataset. This can be an OpenML dataset, e.g. 'http://openml.org/d/1'. -->
+    <xs:element name="paper_url" minOccurs="0" type="xs:anyURI"/> <!-- Link to a paper describing the dataset -->
+  </xs:sequence>
+</xs:complexType>
+
+<xs:simpleType name="system_string64"> <!-- Subset on xs:string. Highly restricted form of string. URL-friendly -->
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([a-zA-Z0-9_\-\.])+"/>
+    <xs:maxLength value="64" />
+     <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="casual_string1024"> <!-- Subset on xs:string. Highly restricted form of string. URL-friendly -->
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([a-zA-Z0-9_\-\.\(\),])+"/>
+    <xs:maxLength value="1024" />
+     <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="casual_string128"> <!-- Subset on xs:string. Highly restricted form of string. URL-friendly -->
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([a-zA-Z0-9_\-\.\(\),])+"/>
+    <xs:maxLength value="128" />
+     <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="casual_string64"> <!-- Subset on xs:string. Highly restricted form of string. URL-friendly -->
+  <xs:restriction base="xs:string">
+     <xs:pattern value="([a-zA-Z0-9_\-\.\(\),])+"/>
+     <xs:maxLength value="64" />
+     <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="basic_latin64">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="\p{IsBasicLatin}*"/>
+    <xs:maxLength value="64" />
+    <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="basic_latin128">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="\p{IsBasicLatin}*"/>
+    <xs:maxLength value="128" />
+    <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="basic_latin1024">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="\p{IsBasicLatin}*"/>
+    <xs:maxLength value="1024" />
+    <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="basic_latin16384">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="\p{IsBasicLatin}*"/>
+    <xs:maxLength value="16384" />
+    <xs:minLength value="1" />
+  </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="access_policy">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="circles" />
+    <xs:enumeration value="public" />
+    <xs:enumeration value="private" />
+  </xs:restriction>
+</xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
As discussed, this api can edit some meta-features of the dataset:
List of  meta-features can  be edited/ updated via data_edit API call,

1. description
2. creator
3. collection_date
4. language
5. citation
6. original_data_url
7. paper_url

These meta-features/ data will just need to call create_dataset api and create a new version: **(python api)**
1. attributes
2. data - the data itself
3. default_target_attribute
4. ignore_attribute
5. row_id_attribute

After the data_edit API is ready, I can create a single **python API** to handle both of these cases.
Based on the arguments (None or otherwise). We can either create a new dataset or call the data_edit API.

### How to test this API?
Create a post request:
Request URL: localhost/api/v1/json/data/edit
Request body: **Specify the data_id and atleast one of the 7 fields to edit as an XML** 


![image](https://user-images.githubusercontent.com/44670788/87136499-e3747100-c29b-11ea-97dc-755703a12b15.png)
example data.xml:
```
<oml:data_edit_parameters xmlns:oml="http://openml.org/openml">
<oml:description> Testing description changes </oml:description>
<oml:creator> sahi </oml:creator>
<oml:contributor> Joaquin Vanschoren</oml:contributor>
<oml:collection_date> 2020 </oml:collection_date>
<oml:language>English</oml:language>
<oml:citation>xxx</oml:citation>
<oml:original_data_url>http://openml.org/d/1</oml:original_data_url>
<oml:paper_url>http://openml.org/d/1</oml:paper_url>
</oml:data_edit_parameters>
```