### PR TITLE
support non-owner edits and sensitive field edits

### DIFF
--- a/openml_OS/views/pages/api_new/v1/xml/data-edit.tpl.php
+++ b/openml_OS/views/pages/api_new/v1/xml/data-edit.tpl.php
@@ -1,3 +1,3 @@
 <oml:data_edit xmlns:oml="http://openml.org/openml">
-    <oml:id><?php echo $dataset->did; ?></oml:id>
+	<oml:id><?php echo $id; ?></oml:id>
 </oml:data_edit>

--- a/openml_OS/views/pages/api_new/v1/xml/data-fork.tpl.php
+++ b/openml_OS/views/pages/api_new/v1/xml/data-fork.tpl.php
@@ -1,0 +1,3 @@
+<oml:data_fork xmlns:oml="http://openml.org/openml">
+	<oml:id><?php echo $id; ?></oml:id>
+</oml:data_fork>

--- a/openml_OS/views/pages/api_new/v1/xml/pre.php
+++ b/openml_OS/views/pages/api_new/v1/xml/pre.php
@@ -511,13 +511,12 @@ $this->apiErrors[1054] = 'Problem inserting in database';
 
 
 //openml.data.edit
-//openml.data.edit
 $this->apiErrors[1060] = 'Problem validating edit_parameters xml';
 $this->apiErrors[1061] = 'Please provide edit_parameters xml';
 $this->apiErrors[1062] = 'Data ID is required';
 $this->apiErrors[1063] = 'Unknown dataset';
-$this->apiErrors[1064] = 'Please provide atleast one field among description, creator, contributor, collection_date, language, citation, original_data_url or paper_url to edit. ';
-$this->apiErrors[1065] = 'Dataset is not owned by you';
+$this->apiErrors[1064] = 'Please provide atleast one field among description, creator, contributor, collection_date, language, citation, original_data_url, default_target_attribute, row_id_attribute, ignore_attribute or paper_url to edit. ';
+$this->apiErrors[1065] = 'Failed to insert record in database while trying to create dataset copy';
 $this->apiErrors[1066] = 'Dataset update failed';
 
 ?>

--- a/openml_OS/views/pages/api_new/v1/xml/pre.php
+++ b/openml_OS/views/pages/api_new/v1/xml/pre.php
@@ -516,7 +516,14 @@ $this->apiErrors[1061] = 'Please provide edit_parameters xml';
 $this->apiErrors[1062] = 'Data ID is required';
 $this->apiErrors[1063] = 'Unknown dataset';
 $this->apiErrors[1064] = 'Please provide atleast one field among description, creator, contributor, collection_date, language, citation, original_data_url, default_target_attribute, row_id_attribute, ignore_attribute or paper_url to edit. ';
-$this->apiErrors[1065] = 'Failed to insert record in database while trying to create dataset copy';
-$this->apiErrors[1066] = 'Dataset update failed';
+$this->apiErrors[1065] = 'Critical features default_target_attribute, row_id_attribute and ignore_attribute can be edited only by the owner. Fork the dataset if changes are required.';
+$this->apiErrors[1066] = 'Critical features default_target_attribute, row_id_attribute and ignore_attribute can only be edited for datasets without any tasks.';
+$this->apiErrors[1067] = 'Dataset update failed';
+
+
+//openml.data.edit
+$this->apiErrors[1070] = 'Data ID is required';
+$this->apiErrors[1071] = 'Unknown dataset';
+$this->apiErrors[1072] = 'Failed to insert record in database';
 
 ?>

--- a/openml_OS/views/pages/api_new/v1/xsd/openml.data.edit.xsd
+++ b/openml_OS/views/pages/api_new/v1/xsd/openml.data.edit.xsd
@@ -14,6 +14,9 @@
     <xs:element name="collection_date" minOccurs="0" type="oml:basic_latin128"/>  <!-- The date the data was originally collected, given by the uploader -->
     <xs:element name="language" minOccurs="0" type="oml:casual_string128"/> <!-- Language in which the data is represented. Starts with 1 upper case letter, rest lower case, e.g. 'English' -->
     <!-- other -->
+    <xs:element name="default_target_attribute" minOccurs="0" type="oml:casual_string1024"/>  <!-- The default target attribute, if it exists. Can also have multiple values (comma-separated). Of course, tasks can be defined that use another attribute as target -->  
+    <xs:element name="row_id_attribute" minOccurs="0" type="oml:casual_string128"/>  <!-- The attribute that represents the row-id column, if present in the dataset. If not set, the tool should create a string rowid from 0 to (n.obs - 1). This is what is then used in the data splits object. If set, it should of course be excluded in modeling -->
+    <xs:element name="ignore_attribute" minOccurs="0" maxOccurs="unbounded" type="oml:casual_string128"/>  <!-- Attributes that should be excluded in modelling, such as identifiers and indexes. -->
     <xs:element name="citation" minOccurs="0" type="oml:basic_latin1024"/> <!-- Reference(s) that should be cited when building on this data -->
     <xs:element name="original_data_url" minOccurs="0" type="xs:anyURI"/> <!-- For derived data, the url to the original dataset. This can be an OpenML dataset, e.g. 'http://openml.org/d/1'. -->
     <xs:element name="paper_url" minOccurs="0" type="xs:anyURI"/> <!-- Link to a paper describing the dataset -->


### PR DESCRIPTION
Two new scenarios are supported in the data_edit API as part of this PR
**Editing by non-owner of the dataset** 

- Clones the dataset with different user ID => yields new Data ID
- Uses the same "arff" file as we are just cloning the row in DB
- Edits the requested fields in the new ID 
- **The old data ID remains unchanged**


**Editing sensitive meta-data by dataset owner** 

- default_target_attribute, ignore_attribute, row_id_attribute
- Clones the dataset => yields new Data ID
- Uses the same "arff" file as we are just cloning the row in DB
- Edits the requested sensitive fields in the new ID 
- **The old data ID remains unchanged**

The summar of handling of different scenarios is shown in the table here:
![image](https://user-images.githubusercontent.com/44670788/89640243-7b6f7580-d8af-11ea-9c9d-50c257d9efed.png)


