### PR TITLE
fix bibtex for python paper

### DIFF
--- a/openml_OS/views/pages/frontend/cite/body.php
+++ b/openml_OS/views/pages/frontend/cite/body.php
@@ -34,7 +34,7 @@
 
     <div id="ppaper" class="collapse" style="font-family: monospace;">
     @article{OpenMLPython2019,<br>
-     author = {Matthias Feurer, Jan N. van Rijn, Arlind Kadra, Pieter Gijsbers, Neeratyoy Mallik, Sahithya Ravi, Andreas Mueller, Joaquin Vanschoren, Frank Hutter},<br>
+     author = {Matthias Feurer and Jan N. van Rijn and Arlind Kadra and Pieter Gijsbers and Neeratyoy Mallik and Sahithya Ravi and Andreas Mueller and Joaquin Vanschoren and Frank Hutter},<br>
      title = {OpenML-Python: an extensible Python API for OpenML},<br>
      journal = {arXiv},<br>
      volume = {1911.02490},<br>


### PR DESCRIPTION
Fix for this comment from Pascal Baillehache:

I've noticed that the BibTex on https://www.openml.org/cite for OpenMLPython2019 triggers a "Too many commas in name..." when processed with pdflatex. According to https://www.texfaq.org/FAQ-manyauthor the authors' name should be separated with 'and' instead of commas.
