### PR TITLE
Point .pq files to datasets bucket

### DIFF
--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -764,8 +764,11 @@ class Api_data extends MY_Api_Model {
       $dataset->status = $data_status->status;
     }
     if ($dataset->format != 'Sparse_ARFF') {
-      $dataset->parquet_url = 'http://openml1.win.tue.nl/dataset' . $data_id . '/dataset_' . $data_id . '.pq';      
-      $dataset->minio_url = 'http://openml1.win.tue.nl/dataset' . $data_id . '/dataset_' . $data_id . '.pq';
+      $bracket = sprintf('%04d', floor($data_id / 10000));
+      $padded_id = sprintf('%04d', $data_id);
+      $url = MINIO_URL . 'datasets/' . $bracket . '/' . $padded_id . '/dataset_' . $data_id . '.pq';
+      $dataset->parquet_url = $url;
+      $dataset->minio_url = $url;
     }
       $this->xmlContents( 'data-get', $this->version, $dataset );
   }


### PR DESCRIPTION
## Goal
See https://github.com/orgs/openml/projects/5?pane=issue&itemId=46514884 for the goal & reasoning.

## In this PR
The .pq url is changed from
https://openml1.win.tue.nl/dataset45714/dataset_45714.pq to
https://openml1.win.tue.nl/datasets/0004/45714/dataset_45714.pq

## How to test
I haven't tested this thoroughly. I just ran
```php
$MINIO_URL = 'http://openml1.win.tue.nl/';
$data_id = 45714;
$bracket = sprintf('%04d', floor($data_id / 10000));
$padded_id = sprintf('%04d', $data_id);
$url = $MINIO_URL . 'datasets/' . $bracket . '/' . $padded_id . '/dataset_' . $data_id . '.pq';
echo($url);
```
In a php-sandbox and checked the resulting url.