### PR TITLE
Don't serve parquet from test server as they point to production

### DIFF
--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -842,6 +842,9 @@ class Api_data extends MY_Api_Model {
     if ($data_status != false) {
       $dataset->status = $data_status->status;
     }
+    // The BASE_URL check prevents servering parquet urls from the test server,
+    // which is needed as long as the test server does not have its own dedicated
+    // MinIO with parquet files. TODO: Remove this after running MinIO on test
     if ($dataset->format != 'Sparse_ARFF' && BASE_URL != "https://test.openml.org/") {
       $bracket = sprintf('%04d', floor($data_id / 10000));
       $padded_id = sprintf('%04d', $data_id);

--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -842,7 +842,7 @@ class Api_data extends MY_Api_Model {
     if ($data_status != false) {
       $dataset->status = $data_status->status;
     }
-    if ($dataset->format != 'Sparse_ARFF') {
+    if ($dataset->format != 'Sparse_ARFF' && BASE_URL != "https://test.openml.org/") {
       $bracket = sprintf('%04d', floor($data_id / 10000));
       $padded_id = sprintf('%04d', $data_id);
       $url = MINIO_URL . 'datasets/' . $bracket . '/' . $padded_id . '/dataset_' . $data_id . '.pq';


### PR DESCRIPTION
The generated parquet urls point to production datasets, which is wrong for the test server. Until we deploy the test server with dedicated MinIO instance, we can use this work-around. 