### PR TITLE
Fix link case in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 Awesome, we're happy to have you! :star2: :tada: :clap:
 
 :point_right: Check out our contributing guide in 
-the [OpenML docs](https://docs.openml.org/Contributing/).
+the [OpenML docs](https://docs.openml.org/contributing/).
 
 


### PR DESCRIPTION
Fixed broken link in contributing.md 

https://docs.openml.org/Contributing/  -> https://docs.openml.org/contributing/