### PR TITLE
Added labeler workflow 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,56 @@
+# Label PRs based on the paths of files being changed
+
+'documentation':
+  - '**/*.md'
+  - 'docs/**/*'
+
+'dependencies':
+  - '**/composer.json'
+  - '**/composer.lock'
+  - '**/package.json'
+  - '**/package-lock.json'
+
+'frontend':
+  - 'css/**/*'
+  - 'js/**/*'
+  - 'img/**/*'
+  - 'fonts/**/*'
+  - '**/*.css'
+  - '**/*.js'
+  - '**/*.html'
+
+'backend':
+  - 'openml_OS/**/*.php'
+  - 'system/**/*'
+
+'database':
+  - 'data/sql/**/*'
+  - '**/*.sql'
+
+'docker':
+  - 'docker/**/*'
+  - 'Dockerfile'
+  - 'docker-compose.yml'
+
+'ci/cd':
+  - '.github/**/*'
+
+'api':
+  - 'openapi/**/*'
+  - '**/*swagger*'
+  - '**/api/**/*'
+
+'security':
+  - '**/security/**/*'
+  - '.github/workflows/security.yml'
+
+'tests':
+  - '**/*test*'
+  - '**/*spec*'
+
+'configuration':
+  - '**/*.conf'
+  - '**/*.config'
+  - '**/*.yaml'
+  - '**/*.yml'
+  - '**/*.json'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,57 @@
+# This workflow automatically labels pull requests based on the files changed
+#
+# Labels help organize and categorize PRs for easier review and tracking.
+# The labeling rules are defined in .github/labeler.yml
+
+name: 'Auto Label PRs'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Labeler
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+  size-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Add Size Labels
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: 10
+          s_label: 'size/s'
+          s_max_size: 100
+          m_label: 'size/m'
+          m_max_size: 500
+          l_label: 'size/l'
+          l_max_size: 1000
+          xl_label: 'size/xl'
+          fail_if_xl: false
+          message_if_xl: >
+            This PR is extremely large. Consider splitting it into smaller PRs for easier review.
+          files_to_ignore: |
+            package-lock.json
+            composer.lock
+            *.min.js
+            *.min.css


### PR DESCRIPTION
Fixes: #1240 

This pull request introduces automated labeling for pull requests using GitHub Actions. The changes make it easier to categorize and track PRs by applying labels based on file paths and PR size.

**Automated PR labeling:**

* Added `.github/labeler.yml` to define label rules based on file paths, including categories like documentation, dependencies, frontend, backend, database, docker, CI/CD, API, security, tests, and configuration.
* Created `.github/workflows/labeler.yml` workflow to automatically apply labels to PRs using the defined rules whenever a PR is opened, synchronized, or reopened.

**PR size labeling:**

* Added a workflow step in `.github/workflows/labeler.yml` to label PRs by size (xs, s, m, l, xl) and optionally warn for extremely large PRs, ignoring certain files from size calculation.