### PR TITLE
Added stale workflow 

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,75 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+name: 'Mark stale issues and pull requests'
+
+on:
+  schedule:
+    # Run daily at 1:30 UTC
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark/Close Stale Issues and PRs
+        uses: actions/stale@v9
+        with:
+          # Token for GitHub API
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
+          # Issue Configuration
+          stale-issue-message: |
+            👋 This issue has been automatically marked as stale because it has not had recent activity. 
+            It will be closed in 14 days if no further activity occurs. 
+            
+            If this issue is still relevant, please leave a comment to keep it open.
+            Thank you for your contributions! 🙏
+          close-issue-message: |
+            🔒 This issue has been automatically closed because it has not had recent activity.
+            
+            If you believe this issue is still relevant, please feel free to reopen it or create a new issue with updated information.
+            Thank you for your understanding! 🙏
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,bug,enhancement,good first issue,help wanted'
+          
+          # Pull Request Configuration
+          stale-pr-message: |
+            👋 This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 7 days if no further activity occurs.
+            
+            If you're still working on this PR, please leave a comment to keep it open.
+            Thank you for your contributions! 🙏
+          close-pr-message: |
+            🔒 This pull request has been automatically closed due to inactivity.
+            
+            If you'd like to continue working on this, please feel free to reopen it or submit a new pull request.
+            Thank you for your understanding! 🙏
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned,security,work-in-progress,dependencies'
+          
+          # General Configuration
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          ascending: false
+          exempt-all-milestones: true
+          
+          # Don't mark issues/PRs as stale if they have assignees
+          exempt-assignees: true
+          
+          # Custom Labels
+          labels-to-add-when-unstale: ''
+          labels-to-remove-when-unstale: 'stale'


### PR DESCRIPTION
Fixes #1242 

This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests in the repository. The workflow is designed to help keep the issue and PR list clean by warning about inactivity and eventually closing items that have not seen recent activity.

**Automation for stale issues and pull requests:**

* Added `.github/workflows/stale.yml` to mark issues as stale after 60 days of inactivity and close them after 14 more days, with custom warning and closing messages.
* Configured pull requests to be marked as stale after 30 days of inactivity and closed after 7 additional days, with separate messages for PRs.