### PR TITLE
linitng setup added for PHP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,49 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# PHP files
+[*.php]
+indent_style = space
+indent_size = 4
+
+# JavaScript files
+[*.js]
+indent_style = space
+indent_size = 2
+
+# CSS files
+[*.css]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefile
+[Makefile]
+indent_style = tab
+
+# SQL files
+[*.sql]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ docs/site/
 *.DS_store
 openml_OS/vendor/
 openapi/vendor/
+
+# PHP linting cache files
+.php-cs-fixer.cache
+.phpcs-cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,50 @@
+<?php
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->in([
+        __DIR__ . '/openml_OS/controllers',
+        __DIR__ . '/openml_OS/models',
+        __DIR__ . '/openml_OS/helpers',
+        __DIR__ . '/openml_OS/libraries',
+        __DIR__ . '/openml_OS/core',
+    ])
+    ->exclude([
+        'vendor',
+        'third_party',
+        'cache',
+        'logs',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'not_operator_with_successor_space' => false,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'phpdoc_scalar' => true,
+        'unary_operator_spaces' => true,
+        'binary_operator_spaces' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['break', 'continue', 'declare', 'return', 'throw', 'try'],
+        ],
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_var_without_name' => true,
+        'single_trait_insert_per_statement' => true,
+        'space_after_semicolon' => true,
+        'no_whitespace_in_blank_line' => true,
+        'concat_space' => ['spacing' => 'one'],
+    ])
+    ->setFinder($finder)
+    ->setLineEnding("\n")
+    ->setIndent("    ") // 4 spaces
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<ruleset name="OpenML Coding Standards">
+    <description>PHP CodeSniffer configuration for OpenML</description>
+
+    <!-- Show progress and use colors -->
+    <arg value="p"/>
+    <arg name="colors"/>
+
+    <!-- Use PSR-12 as base standard -->
+    <rule ref="PSR12"/>
+
+    <!-- Check these directories -->
+    <file>openml_OS/controllers</file>
+    <file>openml_OS/models</file>
+    <file>openml_OS/helpers</file>
+    <file>openml_OS/libraries</file>
+    <file>openml_OS/core</file>
+
+    <!-- Exclude vendor and third-party directories -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/third_party/*</exclude-pattern>
+    <exclude-pattern>*/cache/*</exclude-pattern>
+    <exclude-pattern>*/logs/*</exclude-pattern>
+    <exclude-pattern>*/system/*</exclude-pattern>
+
+    <!-- Relaxed rules for legacy CodeIgniter code -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Allow CodeIgniter naming conventions -->
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Set encoding -->
+    <config name="encoding" value="utf-8"/>
+
+    <!-- Set tab width -->
+    <arg name="tab-width" value="4"/>
+</ruleset>

--- a/openml_OS/composer.json
+++ b/openml_OS/composer.json
@@ -18,6 +18,14 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsstream": "1.6.*"
+		"mikey179/vfsstream": "1.6.*",
+		"squizlabs/php_codesniffer": "^3.7",
+		"friendsofphp/php-cs-fixer": "^3.40"
+	},
+	"scripts": {
+		"lint": "phpcs --standard=.phpcs.xml",
+		"lint:fix": "phpcbf --standard=.phpcs.xml",
+		"cs:check": "php-cs-fixer fix --dry-run --diff",
+		"cs:fix": "php-cs-fixer fix"
 	}
 }


### PR DESCRIPTION
Fixes: #1256

This pull request introduces a standardized approach to code style and quality enforcement for the project, focusing on PHP and related files. The main improvements are the addition of configuration files and development dependencies to automate code formatting and linting, as well as new scripts to make these tools easy to use.

**Code style and quality enforcement:**

* Added `.editorconfig` to ensure consistent coding styles across all supported file types (PHP, JS, CSS, JSON, YAML, Markdown, Makefile, SQL), including rules for indentation, charset, line endings, and whitespace trimming.
* Added `.php-cs-fixer.php` configuration to define and enforce PHP code style rules (PSR-12 and others), specifying which directories to check and which to exclude, plus cache settings for faster runs.
* Added `.phpcs.xml` to configure PHP_CodeSniffer with PSR-12 as the base standard, directory inclusions/exclusions, relaxed rules for legacy CodeIgniter code, and settings for encoding and tab width.

**Development tooling:**

* Updated `openml_OS/composer.json` to add `squizlabs/php_codesniffer` and `friendsofphp/php-cs-fixer` as dev dependencies, and introduced composer scripts for linting and code style checks/fixes, making it easy for developers to run these tools.


## Available Commands

- composer run lint - Check violations
- composer run lint:fix - Auto-fix with PHP_CodeSniffer
- composer run cs:check - Dry-run with PHP-CS-Fixer
- composer run cs:fix - Fix with PHP-CS-Fixer
- 