### PR TITLE
ElasticSearch user mapping: first name and last name should use a normalizer to allow case-insensitive sort

### DIFF
--- a/openml_OS/libraries/ElasticSearch.php
+++ b/openml_OS/libraries/ElasticSearch.php
@@ -169,6 +169,14 @@ class ElasticSearch {
                     'type' => 'date',
                     'format' => 'yyyy-MM-dd HH:mm:ss'
                 ),
+                'first_name' => array(
+                    'type' => 'keyword',
+                    'normalizer' => 'lowercase_normalizer'
+                ),
+                'last_name' => array(
+                    'type' => 'keyword',
+                    'normalizer' => 'lowercase_normalizer'
+                ),
                 'suggest' => array(
                     'type' => 'completion',
                     'analyzer' => 'standard'
@@ -387,6 +395,14 @@ class ElasticSearch {
 		    'index' => array(
             		'number_of_shards' => 1,
             		'number_of_replicas' => 0
+		    ),
+		    'analysis' => array(
+            		'normalizer' => array(
+                		'lowercase_normalizer' => array(
+                    		    'type' => 'custom',
+                    		    'filter' => array('lowercase')
+                		)
+            		)
 		    )
 		),
 		'mappings' => array(


### PR DESCRIPTION
Fixes: #1199 
This pull request updates the Elasticsearch configuration in `openml_OS/libraries/ElasticSearch.php` to improve the indexing and search capabilities for user names. The main changes are the addition of new fields for first and last names with case-insensitive keyword indexing, and the introduction of a custom normalizer to ensure consistent lowercase storage and querying.

**Elasticsearch mapping improvements:**

* Added `first_name` and `last_name` fields to the mapping, both using the `keyword` type and a `lowercase_normalizer` for case-insensitive searches.

**Elasticsearch analysis configuration:**

* Introduced a `lowercase_normalizer` in the index analysis settings, defined as a custom normalizer with a lowercase filter, to support the new case-insensitive keyword fields.