### PR TITLE
Fix #1200 – JSON data/tag endpoint returns XML errors

### DIFF
--- a/openml_OS/controllers/Api_new.php
+++ b/openml_OS/controllers/Api_new.php
@@ -141,23 +141,23 @@ class Api_new extends CI_Controller {
     
     // TODO: very important (for future versions of the API)! 
     if ($this->database_connection_error) {
-      $this->Api_data->returnError(107, $this->version);
+      $this->Api_data->returnError(107, $this->version, 412, null, false, false, $outputFormat);
       return;
     }
     
     $request_type = strtolower($_SERVER['REQUEST_METHOD']);
     if ($this->authenticated == false && $request_type != 'get') {
       if ($this->provided_hash) {
-        $this->Api_data->returnError(103, $this->version);
+        $this->Api_data->returnError(103, $this->version, 412, null, false, false, $outputFormat);
       } else {
-        $this->Api_data->returnError(102, $this->version);
+        $this->Api_data->returnError(102, $this->version, 412, null, false, false, $outputFormat);
       }
     } else if ($this->authenticated == false && $this->provided_hash) {
-        $this->Api_data->returnError(103, $this->version);
+      $this->Api_data->returnError(103, $this->version, 412, null, false, false, $outputFormat);
     } else if ($this->user_has_writing_rights == false && $request_type != 'get') {
-      $this->Api_data->returnError(104, $this->version, $this->openmlGeneralErrorCode, 'API calls of the read-only user can only be of type GET. ');
+      $this->Api_data->returnError(104, $this->version, $this->openmlGeneralErrorCode, 'API calls of the read-only user can only be of type GET. ', false, false, $outputFormat);
     } else if (file_exists(APPPATH.'models/api/' . $this->version . '/Api_' . $type . '.php') == false && $type != 'xsd' && $type != 'xml_example' && $type != 'arff_example') {
-       $this->Api_data->returnError(100, $this->version);
+       $this->Api_data->returnError(100, $this->version, 412, null, false, false, $outputFormat);
     } else if($type == 'xsd') {
       $this->server_document('xsd', $segs[0] . '.xsd', 'v1', 'Content-type: text/xml; charset=utf-8');
     } else if($type == 'xml_example') {

--- a/openml_OS/core/MY_Api_Model.php
+++ b/openml_OS/core/MY_Api_Model.php
@@ -95,14 +95,21 @@ class MY_Api_Model extends CI_Model {
     );
   }
 
-  public function returnError($code, $version, $httpErrorCode = 412, $additionalInfo = null, $emailLog = false, $supress_output = false) {
+  public function returnError($code, $version, $httpErrorCode = 412, $additionalInfo = null, $emailLog = false, $supress_output = false, $outputFormat = null) {
     $this->Log->api_error('error', $_SERVER['REMOTE_ADDR'], $code, $_SERVER['QUERY_STRING'], $this->load->apiErrors[$code] . (($additionalInfo == null)?'':$additionalInfo) );
     $error['code'] = $code;
     $error['message'] = htmlentities( $this->load->apiErrors[$code] );
     $error['additional'] = htmlentities( $additionalInfo );
     if (!$supress_output) {
       http_response_code($httpErrorCode);
+      $originalFormat = $this->outputFormat;
+      if ($outputFormat !== null) {
+        $this->outputFormat = $outputFormat;
+      }
       $this->xmlContents('error-message', $version, $error);
+      if ($outputFormat !== null) {
+        $this->outputFormat = $originalFormat;
+      }
     }
     if ($emailLog && defined('EMAIL_API_LOG')) {
       $to = EMAIL_API_LOG;

--- a/openml_OS/views/pages/api_new/v1/json/error-message.tpl.php
+++ b/openml_OS/views/pages/api_new/v1/json/error-message.tpl.php
@@ -1,0 +1,12 @@
+<?php
+$error_response = array(
+  'error' => array(
+    'code' => $code,
+    'message' => $message
+  )
+);
+if ($additional != null) {
+  $error_response['error']['additional_information'] = $additional;
+}
+echo json_encode($error_response);
+?>


### PR DESCRIPTION
Adds JSON error responses for API v1 endpoints. When clients request /api_new/v1/json/*, errors now return JSON instead of XML.

Solves #1200
Before : 
<img width="1113" height="300" alt="image" src="https://github.com/user-attachments/assets/544662d5-31ad-47da-b067-78aa34ec27bb" />
After : 
<img width="453" height="223" alt="image" src="https://github.com/user-attachments/assets/1d1b48d9-a87b-4ff9-b3ef-9619e1fc6aa6" />

### Changes

- Added `openml_OS/views/pages/api_new/v1/json/error-message.tpl.php` to provide consistent JSON-formatted error responses.
- New JSON error schema:
  ```json
  {
    "error": {
      "code": "<code>",
      "message": "<message>",
      "additional_information": "<info>"
    }
  }
