### PR TITLE
Do not use the kaggle table when indexing datasets 

### DIFF
--- a/openml_OS/libraries/ElasticSearch.php
+++ b/openml_OS/libraries/ElasticSearch.php
@@ -1823,7 +1823,7 @@ class ElasticSearch {
       	$params['index'] = 'data';
       	$params['type'] = 'data';
         $status_sql_variable = 'IFNULL(`s`.`status`, \'' . $this->CI->config->item('default_dataset_status') . '\')';
-        $datasets = $this->db->query('select d.*, ' . $status_sql_variable . ' AS `status`, count(rid) as runs, GROUP_CONCAT(dp.error) as error_message, GROUP_CONCAT(DISTINCT k.kaggle_link) as kaggle_link from dataset d left join (SELECT `did`, MAX(`status`) AS `status` FROM `dataset_status` GROUP BY `did`) s ON s.did = d.did left join task_inputs t on (t.value=d.did and t.input="source_data") left join run r on (r.task_id=t.task_id) left join data_processed dp on (d.did=dp.did) left join kaggle k on (d.did=k.dataset_id)' . ($id ? ' where d.did=' . $id : '') . ' group by d.did');
+        $datasets = $this->db->query('select d.*, ' . $status_sql_variable . ' AS `status`, count(rid) as runs, GROUP_CONCAT(dp.error) as error_message from dataset d left join (SELECT `did`, MAX(`status`) AS `status` FROM `dataset_status` GROUP BY `did`) s ON s.did = d.did left join task_inputs t on (t.value=d.did and t.input="source_data") left join run r on (r.task_id=t.task_id) left join data_processed dp on (d.did=dp.did)' . ($id ? ' where d.did=' . $id : '') . ' group by d.did');
 
         if ($id and ! $datasets)
             return 'Error: data set ' . $id . ' is unknown';
@@ -1875,7 +1875,7 @@ class ElasticSearch {
             $params['body'] = array();
             $valid_ids = array();
             $status_sql_variable = 'IFNULL(`s`.`status`, \'' . $this->CI->config->item('default_dataset_status') . '\')';
-            $datasets = $this->db->query('select d.*, ' . $status_sql_variable . 'AS `status`, count(rid) as runs, GROUP_CONCAT(dp.error) as error_message, GROUP_CONCAT(DISTINCT k.kaggle_link) as kaggle_link from dataset d left join (SELECT `did`, MAX(`status`) AS `status` FROM `dataset_status` GROUP BY `did`) s ON d.did = s.did left join task_inputs t on (t.value=d.did and t.input="source_data") left join run r on (r.task_id=t.task_id) left join data_processed dp on (d.did=dp.did) left join kaggle k on (d.did=k.dataset_id) where d.did>=' . $did . ' and d.did<' . ($did + $incr) . ' group by d.did');
+            $datasets = $this->db->query('select d.*, ' . $status_sql_variable . 'AS `status`, count(rid) as runs, GROUP_CONCAT(dp.error) as error_message from dataset d left join (SELECT `did`, MAX(`status`) AS `status` FROM `dataset_status` GROUP BY `did`) s ON d.did = s.did left join task_inputs t on (t.value=d.did and t.input="source_data") left join run r on (r.task_id=t.task_id) left join data_processed dp on (d.did=dp.did) where d.did>=' . $did . ' and d.did<' . ($did + $incr) . ' group by d.did');
             if($datasets){
               foreach ($datasets as $d) {
                 try {
@@ -1895,24 +1895,22 @@ class ElasticSearch {
               $responses = $this->client->bulk($params);
               $submitted += sizeof($responses['items']);
 
-        //clean up, just to be sure
+              //clean up, just to be sure
               $params_del['index'] = 'data';
-        foreach(array_diff(range($did,$did+$incr-1),$valid_ids) as $delid){
-            $params_del['id'] = $delid;
-      try{
-        $this->client->delete($params_del);
-      }
-      catch (Exception $e) {
-        $result = json_decode($e);
-                    if($result['found']=='true' && $verbosity)
-                        echo "deleted_".$delid." ";
-                  }
-         }
+                foreach(array_diff(range($did,$did+$incr-1),$valid_ids) as $delid){
+                    $params_del['id'] = $delid;
+                      try{
+                        $this->client->delete($params_del);
+                      }
+                      catch (Exception $e) {
+                        $result = json_decode($e);
+                        if($result['found']=='true' && $verbosity)
+                            echo "deleted_".$delid." ";
+                      }
+                 }
             }
-
             $did += $incr;
         }
-
         return 'Successfully indexed ' . $submitted . ' out of ' . $datacount . ' datasets.';
     }
 


### PR DESCRIPTION
As far as I know, the `kaggle_link`s have been a test. I don't see it used anywhere. To avoid exceptions when indexing datasets, using https://github.com/openml/services, I removed `kaggle_links`.