### PR TITLE
Security hardening fixed

### DIFF
--- a/docker/config/api.conf
+++ b/docker/config/api.conf
@@ -15,7 +15,7 @@ HostnameLookups Off
 </Directory>
 
 <Directory /var/www/openml>
-	Options Indexes FollowSymLinks MultiViews
+	Options -Indexes FollowSymLinks MultiViews
 	AllowOverride All
 	Require all granted
 </Directory>

--- a/docker/config/php.ini
+++ b/docker/config/php.ini
@@ -407,7 +407,7 @@ zend.exception_string_param_max_len = 0
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
 ; https://php.net/expose-php
-expose_php = On
+expose_php = Off
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;
@@ -426,7 +426,7 @@ max_execution_time = 30
 ; Development Value: 60 (60 seconds)
 ; Production Value: 60 (60 seconds)
 ; https://php.net/max-input-time
-max_input_time = 60
+max_input_time = 3600
 
 ; Maximum input variable nesting level
 ; https://php.net/max-input-nesting-level


### PR DESCRIPTION
Updated OpenML/docker/config/php.ini to harden the PHP runtime: turned off expose_php so responses no longer include the PHP signature, and raised max_input_time to 3600 seconds to keep multi‑GB multipart uploads from failing mid‑stream. 


Adjusted OpenML/docker/config/api.conf so the document root uses Options -Indexes ..., preventing Apache from serving directory listings for the API.