### PR TITLE
Set options to abort setup if something goes wrong

### DIFF
--- a/docker/set_configuration.sh
+++ b/docker/set_configuration.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euxo pipefail
+
 # TODO: read credentials from secrets instead
 OPENML_PATH=${OPENML_PATH:-/var/www/}
 BASE_CONFIG_PATH=${OPENML_PATH}openml/openml_OS/config/BASE_CONFIG.php


### PR DESCRIPTION
My PHP server happily started and building indices and then later it turned out because I was mounting my local directly it never actually configured the `BASE_CONFIG` with sed (since there was none). Would've been nice if the container just failed on startup instead :)