### PR TITLE
feat: add comprehensive code quality tools (closes #1272)

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1,0 +1,66 @@
+name: PHP Quality Checks
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Static Analysis & Code Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, mysqli
+          coverage: none
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        working-directory: openml_OS
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('openml_OS/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies (including dev)
+        run: composer install --prefer-dist --no-progress --no-interaction
+        working-directory: openml_OS
+
+      - name: PHP-CS-Fixer — check code style (dry run)
+        run: composer run cs:check
+        working-directory: openml_OS
+
+      - name: PHPStan — static analysis (level 3)
+        run: composer run phpstan
+        working-directory: openml_OS
+
+      - name: Psalm — static analysis (level 8, informational)
+        # continue-on-error so Psalm reports issues without blocking PRs initially.
+        # Remove this once the codebase is clean enough to enforce.
+        continue-on-error: true
+        run: composer run psalm
+        working-directory: openml_OS
+
+      - name: PHPMD — code smell detection (informational)
+        # continue-on-error so PHPMD reports issues without blocking PRs initially.
+        # Remove this once the codebase is clean enough to enforce.
+        continue-on-error: true
+        run: composer run phpmd
+        working-directory: openml_OS

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * PHP-CS-Fixer configuration for OpenML.
+ *
+ * Enforces PSR-12 coding style across the openml_OS application directory.
+ * Run checks:  composer run cs:check
+ * Auto-fix:    composer run cs:fix
+ */
+
+$config = new PhpCsFixer\Config();
+
+return $config
+    ->setRules([
+        '@PSR12'              => true,
+        '@PHP74Migration'     => true,
+        'array_syntax'        => ['syntax' => 'short'],
+        'no_unused_imports'   => true,
+        'ordered_imports'     => ['sort_algorithm' => 'alpha'],
+        'single_quote'        => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'no_trailing_whitespace'      => true,
+        'no_extra_blank_lines'        => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__ . '/openml_OS')
+            ->exclude([
+                'libraries',
+                'third_party',
+                'vendor',
+                'cache',
+                'logs',
+            ])
+            ->name('*.php')
+    )
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,0 +1,16 @@
+parameters:
+    level: 3
+    paths:
+        - openml_OS
+    excludePaths:
+        - openml_OS/libraries/*
+        - openml_OS/third_party/*
+        - openml_OS/vendor/*
+        - openml_OS/cache/*
+        - openml_OS/logs/*
+    ignoreErrors:
+        # CodeIgniter magic properties are not resolvable by static analysis
+        - '#Access to an undefined property CI_Controller::#'
+        - '#Call to an undefined method CI_Controller::#'
+    checkMissingIterableValueType: false
+    reportUnmatchedIgnoredErrors: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,57 @@
+# Contributing to OpenML
+
 ### Want to get involved?
+
 Awesome, we're happy to have you! :star2: :tada: :clap:
 
-:point_right: Check out our contributing guide in 
+:point_right: Check out our contributing guide in
 the [OpenML docs](https://docs.openml.org/Contributing/).
 
+---
+
+## Code Quality
+
+This project uses four code quality tools to keep the codebase consistent and catch bugs early.
+All tools are installed as Composer **dev** dependencies.
+
+### Setup
+
+```bash
+# From the openml_OS/ directory:
+cd openml_OS
+php composer.phar install
+```
+
+### Available commands
+
+| Command              | What it does                                      |
+| -------------------- | ------------------------------------------------- |
+| `composer run cs:check` | Check code style (PSR-12) — **no changes made** |
+| `composer run cs:fix`   | Auto-fix code style issues                      |
+| `composer run phpstan`  | Run PHPStan static analysis (level 3)           |
+| `composer run psalm`    | Run Psalm static analysis (level 8)             |
+| `composer run phpmd`    | Run PHPMD code smell detection                  |
+
+### Before submitting a PR
+
+1. Run `composer run cs:fix` to auto-fix formatting.
+2. Run `composer run phpstan` and fix any reported errors.
+3. Review (but don't worry about fixing all) Psalm and PHPMD output — these are informational for now.
+
+### Raising the analysis level
+
+PHPStan and Psalm are intentionally set to permissive levels (3 and 8 respectively) to accommodate the existing legacy codebase.
+As issues are fixed, the levels can be raised:
+
+- **PHPStan**: edit `.phpstan.neon` → increase `level` (max is 9)
+- **Psalm**: edit `psalm.xml` → decrease `errorLevel` (min is 1)
+
+Config files are in the **repo root**:
+
+| File                  | Tool           |
+| --------------------- | -------------- |
+| `.phpstan.neon`       | PHPStan        |
+| `.php-cs-fixer.php`   | PHP-CS-Fixer   |
+| `psalm.xml`           | Psalm          |
+| `phpmd.xml`           | PHPMD          |
 

--- a/openml_OS/composer.json
+++ b/openml_OS/composer.json
@@ -18,6 +18,17 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsstream": "1.6.*"
+		"mikey179/vfsstream": "1.6.*",
+		"phpstan/phpstan": "^1.10",
+		"vimeo/psalm": "^5.0",
+		"friendsofphp/php-cs-fixer": "^3.0",
+		"phpmd/phpmd": "^2.14"
+	},
+	"scripts": {
+		"cs:check": "php-cs-fixer fix --dry-run --diff --config=../.php-cs-fixer.php",
+		"cs:fix": "php-cs-fixer fix --config=../.php-cs-fixer.php",
+		"phpstan": "phpstan analyse -c ../.phpstan.neon --memory-limit=512M",
+		"psalm": "psalm --config=../psalm.xml --output-format=compact",
+		"phpmd": "phpmd . text ../phpmd.xml --exclude libraries,third_party,vendor,cache,logs"
 	}
 }

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<ruleset name="OpenML PHPMD Ruleset"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+    <description>
+        PHPMD ruleset for OpenML. Detects code smells, unused code, and naming issues.
+        Thresholds are relaxed to accommodate the existing legacy codebase.
+        Tighten these values gradually as the codebase is refactored.
+    </description>
+
+    <!-- Code size rules -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <!-- Legacy controllers (Api.php) are very large; start permissive -->
+            <property name="reportLevel" value="20"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="minimum" value="400"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="2000"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
+        <properties>
+            <property name="minimum" value="12"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount">
+        <properties>
+            <property name="minimum" value="60"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/TooManyFields">
+        <properties>
+            <property name="maxfields" value="20"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="40"/>
+        </properties>
+    </rule>
+
+    <!-- Unused code rules -->
+    <rule ref="rulesets/unusedcode.xml"/>
+
+    <!-- Naming rules -->
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <!-- Allow common short vars like $id, $db -->
+            <property name="minimum" value="2"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/LongVariable">
+        <properties>
+            <property name="maximum" value="40"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/ShortMethodName"/>
+    <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
+    <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+    <rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
+
+</ruleset>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="8"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedVariablesAndParams="false"
+    findUnusedCode="false"
+>
+    <!--
+        errorLevel 8 = most permissive (fewest errors reported).
+        Gradually lower this value (toward 1) as issues are fixed.
+        See: https://psalm.dev/docs/running_psalm/error_levels/
+    -->
+
+    <projectFiles>
+        <directory name="openml_OS"/>
+        <ignoreFiles>
+            <directory name="openml_OS/libraries"/>
+            <directory name="openml_OS/third_party"/>
+            <directory name="openml_OS/vendor"/>
+            <directory name="openml_OS/cache"/>
+            <directory name="openml_OS/logs"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <!-- Suppress issues common in CodeIgniter 3 magic-property patterns -->
+        <UndefinedMagicPropertyFetch errorLevel="suppress"/>
+        <UndefinedMagicPropertyAssignment errorLevel="suppress"/>
+        <UndefinedMagicMethod errorLevel="suppress"/>
+        <MixedAssignment errorLevel="suppress"/>
+        <MixedReturnStatement errorLevel="suppress"/>
+        <MixedMethodCall errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
- Add .phpstan.neon (level 3, excludes vendor/libraries/third_party)
- Add .php-cs-fixer.php (PSR-12 + PHP74Migration rules)
- Add psalm.xml (error level 8, suppresses CI magic-property issues)
- Add phpmd.xml (codesize, unusedcode, naming rulesets with relaxed thresholds)
- Update openml_OS/composer.json: add PHPStan ^1.10, Psalm ^5.0, PHP-CS-Fixer ^3.0, PHPMD ^2.14 as dev dependencies; add composer scripts
- Add .github/workflows/ci-quality.yml: runs on PRs and pushes to main; PHP-CS-Fixer and PHPStan are enforced; Psalm and PHPMD are informational
- Update CONTRIBUTING.md: add Code Quality section with setup and usage docs