### PR TITLE
Fix/shell injection 1265

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1,0 +1,66 @@
+name: PHP Quality Checks
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Static Analysis & Code Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, mysqli
+          coverage: none
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        working-directory: openml_OS
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('openml_OS/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies (including dev)
+        run: composer install --prefer-dist --no-progress --no-interaction
+        working-directory: openml_OS
+
+      - name: PHP-CS-Fixer — check code style (dry run)
+        run: composer run cs:check
+        working-directory: openml_OS
+
+      - name: PHPStan — static analysis (level 3)
+        run: composer run phpstan
+        working-directory: openml_OS
+
+      - name: Psalm — static analysis (level 8, informational)
+        # continue-on-error so Psalm reports issues without blocking PRs initially.
+        # Remove this once the codebase is clean enough to enforce.
+        continue-on-error: true
+        run: composer run psalm
+        working-directory: openml_OS
+
+      - name: PHPMD — code smell detection (informational)
+        # continue-on-error so PHPMD reports issues without blocking PRs initially.
+        # Remove this once the codebase is clean enough to enforce.
+        continue-on-error: true
+        run: composer run phpmd
+        working-directory: openml_OS

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * PHP-CS-Fixer configuration for OpenML.
+ *
+ * Enforces PSR-12 coding style across the openml_OS application directory.
+ * Run checks:  composer run cs:check
+ * Auto-fix:    composer run cs:fix
+ */
+
+$config = new PhpCsFixer\Config();
+
+return $config
+    ->setRules([
+        '@PSR12'              => true,
+        '@PHP74Migration'     => true,
+        'array_syntax'        => ['syntax' => 'short'],
+        'no_unused_imports'   => true,
+        'ordered_imports'     => ['sort_algorithm' => 'alpha'],
+        'single_quote'        => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'no_trailing_whitespace'      => true,
+        'no_extra_blank_lines'        => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__ . '/openml_OS')
+            ->exclude([
+                'libraries',
+                'third_party',
+                'vendor',
+                'cache',
+                'logs',
+            ])
+            ->name('*.php')
+    )
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,0 +1,16 @@
+parameters:
+    level: 3
+    paths:
+        - openml_OS
+    excludePaths:
+        - openml_OS/libraries/*
+        - openml_OS/third_party/*
+        - openml_OS/vendor/*
+        - openml_OS/cache/*
+        - openml_OS/logs/*
+    ignoreErrors:
+        # CodeIgniter magic properties are not resolvable by static analysis
+        - '#Access to an undefined property CI_Controller::#'
+        - '#Call to an undefined method CI_Controller::#'
+    checkMissingIterableValueType: false
+    reportUnmatchedIgnoredErrors: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,57 @@
+# Contributing to OpenML
+
 ### Want to get involved?
+
 Awesome, we're happy to have you! :star2: :tada: :clap:
 
-:point_right: Check out our contributing guide in 
+:point_right: Check out our contributing guide in
 the [OpenML docs](https://docs.openml.org/Contributing/).
 
+---
+
+## Code Quality
+
+This project uses four code quality tools to keep the codebase consistent and catch bugs early.
+All tools are installed as Composer **dev** dependencies.
+
+### Setup
+
+```bash
+# From the openml_OS/ directory:
+cd openml_OS
+php composer.phar install
+```
+
+### Available commands
+
+| Command              | What it does                                      |
+| -------------------- | ------------------------------------------------- |
+| `composer run cs:check` | Check code style (PSR-12) — **no changes made** |
+| `composer run cs:fix`   | Auto-fix code style issues                      |
+| `composer run phpstan`  | Run PHPStan static analysis (level 3)           |
+| `composer run psalm`    | Run Psalm static analysis (level 8)             |
+| `composer run phpmd`    | Run PHPMD code smell detection                  |
+
+### Before submitting a PR
+
+1. Run `composer run cs:fix` to auto-fix formatting.
+2. Run `composer run phpstan` and fix any reported errors.
+3. Review (but don't worry about fixing all) Psalm and PHPMD output — these are informational for now.
+
+### Raising the analysis level
+
+PHPStan and Psalm are intentionally set to permissive levels (3 and 8 respectively) to accommodate the existing legacy codebase.
+As issues are fixed, the levels can be raised:
+
+- **PHPStan**: edit `.phpstan.neon` → increase `level` (max is 9)
+- **Psalm**: edit `psalm.xml` → decrease `errorLevel` (min is 1)
+
+Config files are in the **repo root**:
+
+| File                  | Tool           |
+| --------------------- | -------------- |
+| `.phpstan.neon`       | PHPStan        |
+| `.php-cs-fixer.php`   | PHP-CS-Fixer   |
+| `psalm.xml`           | Psalm          |
+| `phpmd.xml`           | PHPMD          |
 

--- a/openml_OS/composer.json
+++ b/openml_OS/composer.json
@@ -18,6 +18,17 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsstream": "1.6.*"
+		"mikey179/vfsstream": "1.6.*",
+		"phpstan/phpstan": "^1.10",
+		"vimeo/psalm": "^5.0",
+		"friendsofphp/php-cs-fixer": "^3.0",
+		"phpmd/phpmd": "^2.14"
+	},
+	"scripts": {
+		"cs:check": "php-cs-fixer fix --dry-run --diff --config=../.php-cs-fixer.php",
+		"cs:fix": "php-cs-fixer fix --config=../.php-cs-fixer.php",
+		"phpstan": "phpstan analyse -c ../.phpstan.neon --memory-limit=512M",
+		"psalm": "psalm --config=../psalm.xml --output-format=compact",
+		"phpmd": "phpmd . text ../phpmd.xml --exclude libraries,third_party,vendor,cache,logs"
 	}
 }

--- a/openml_OS/controllers/Api_splits.php
+++ b/openml_OS/controllers/Api_splits.php
@@ -35,7 +35,13 @@ class Api_splits extends CI_Controller {
     
     $task_id = $runs[0]->task_id;
     
-    $command = 'java -jar ' . $this->evaluation . ' -f "different_predictions" -t ' . $task_id . ' -r ' . $run_ids . $this->eval_engine_config;
+    // Escape all shell arguments to prevent command injection.
+    // is_safe() above is the first layer; escapeshellarg() is the second.
+    $command = 'java -jar ' . escapeshellarg($this->evaluation)
+             . ' -f ' . escapeshellarg('different_predictions')
+             . ' -t ' . escapeshellarg((string) $task_id)
+             . ' -r ' . escapeshellarg($run_ids)
+             . $this->eval_engine_config;
     
     $this->Log->cmd('API Splits::different_predictions(' . $run_ids . ')', $command);
     
@@ -59,7 +65,12 @@ class Api_splits extends CI_Controller {
     
     $task_id = $runs[0]->task_id;
     
-    $command = 'java -jar ' . $this->evaluation . ' -f "all_wrong" -t ' . $task_id . ' -r ' . $run_ids . $this->eval_engine_config;
+    // Escape all shell arguments to prevent command injection.
+    $command = 'java -jar ' . escapeshellarg($this->evaluation)
+             . ' -f ' . escapeshellarg('all_wrong')
+             . ' -t ' . escapeshellarg((string) $task_id)
+             . ' -r ' . escapeshellarg($run_ids)
+             . $this->eval_engine_config;
     
     $this->Log->cmd('API Splits::all_wrong(' . $run_ids . ')', $command);
     
@@ -81,10 +92,11 @@ class Api_splits extends CI_Controller {
     $offset = "";
     $size = "";
     if (is_numeric($offset_arg)) {
-      $offset = ' -o ' . $offset_arg . ' ';
+      // Cast to int so only a bare integer reaches the shell.
+      $offset = ' -o ' . escapeshellarg((string)(int) $offset_arg) . ' ';
       
       if (is_numeric($size_arg)) {
-        $size = ' -size ' . $size_arg . ' ';
+        $size = ' -size ' . escapeshellarg((string)(int) $size_arg) . ' ';
       }
     }
     
@@ -93,7 +105,14 @@ class Api_splits extends CI_Controller {
       die('Task not valid challenge.');
     }
     
-    $command = 'java -jar ' . $this->evaluation . ' -f "challenge" -t ' . $task_id . ' -mode "' . $testtrain . '" ' . $offset . $size . $this->eval_engine_config;
+    // Escape all shell arguments to prevent command injection.
+    // $testtrain is already validated against a whitelist above.
+    $command = 'java -jar ' . escapeshellarg($this->evaluation)
+             . ' -f ' . escapeshellarg('challenge')
+             . ' -t ' . escapeshellarg((string)(int) $task_id)
+             . ' -mode ' . escapeshellarg($testtrain)
+             . ' ' . $offset . $size
+             . $this->eval_engine_config;
     
     $this->Log->cmd('API Splits::challenge(' . $task_id . ', ' . $testtrain . ')', $command);
     
@@ -145,17 +164,22 @@ class Api_splits extends CI_Controller {
     // TODO: very important. sanity check input
     $testset_str = array_key_exists('custom_testset', $values) && is_cs_natural_numbers($values['custom_testset']) ? '-test "' . $values['custom_testset'] . '"' : '';
     
-    $command = 'java -jar ' . $this->evaluation . ' -f "' . $function . '" -id ' . $task_id . ' ' . $this->eval_engine_config;
+    // Escape all shell arguments to prevent command injection.
+    // $function is an internal string, but escaped as defence-in-depth.
+    $command = 'java -jar ' . escapeshellarg($this->evaluation)
+             . ' -f ' . escapeshellarg($function)
+             . ' -id ' . escapeshellarg((string)(int) $task_id)
+             . ' ' . $this->eval_engine_config;
     
-    if (array_key_exists('custom_testset', $values)) {
-      $command .= '-test "' . $values['custom_testset'] . '" ';
+    if (array_key_exists('custom_testset', $values) && is_cs_natural_numbers($values['custom_testset'])) {
+      $command .= '-test ' . escapeshellarg($values['custom_testset']) . ' ';
     }
     
     if (!file_exists(dirname($filepath))) {
       mkdir(dirname($filepath), 0755, true);
     }
     
-    $command .= ' -o ' . $filepath;
+    $command .= ' -o ' . escapeshellarg($filepath);
     
     if (function_enabled('exec')) {
       header('Content-type: text/plain');

--- a/openml_OS/helpers/api_helper.php
+++ b/openml_OS/helpers/api_helper.php
@@ -135,22 +135,28 @@ function get_arff_features( $datasetUrl, $class = false ) {
   $res = array();
   $code = 0;
 
-  $heap = '-Xmx' . ( $ci->input->is_cli_request() ?
-    $ci->config->item('java_heap_space_cli') :
-    $ci->config->item('java_heap_space_web') );
+  $heapSize = $ci->input->is_cli_request()
+    ? $ci->config->item('java_heap_space_cli')
+    : $ci->config->item('java_heap_space_web');
 
-  $command = "java $heap -jar $eval -f data_features -d $datasetUrl";
-  if($class != false)
-    $command .= ' -c ' . $class;
+  // Escape all arguments passed to the shell to prevent command injection.
+  $command = 'java ' . escapeshellarg('-Xmx' . $heapSize)
+           . ' -jar ' . escapeshellarg($eval)
+           . ' -f data_features'
+           . ' -d ' . escapeshellarg($datasetUrl);
+
+  if ($class != false) {
+    $command .= ' -c ' . escapeshellarg((string) $class);
+  }
 
   $ci->Log->cmd( 'ARFF Feature Extractor', $command );
 
-  if(function_enabled('exec') === false ) {
+  if (function_enabled('exec') === false) {
     return false;
   }
   exec( CMD_PREFIX . $command, $res, $code );
 
-  if( $code == 0 && is_array( $res ) ) {
+  if ( $code == 0 && is_array( $res ) ) {
     return json_decode( implode( "\n", $res ) );
   } else {
     return false;
@@ -180,11 +186,16 @@ function validate_arff( $to_folder, $filepath, $name, $did ) {
 
   exec( CMD_PREFIX . $command, $res, $code );
 
-  //Guess the id of the dataset and add it to the top of the file
-  $info = '% Data set "'.$name.'". For more information, see http:\/\/openml.org\/d\/'.$did;
-  $string = '1s/^/'.$info.'\n/';
-  $command2 = "sed -i -e '$string' $newUrl";
-  exec( CMD_PREFIX . $command2, $res, $code );
+  // Prepend dataset info comment using pure PHP file I/O.
+  // This replaces the previous `sed` shell invocation, eliminating the
+  // command-injection risk that existed when $name contained shell metacharacters.
+  $safeName = str_replace(["%", "\r", "\n"], ['', '', ''], $name);
+  $comment  = '% Data set "' . $safeName . '". For more information, see https://openml.org/d/' . (int) $did . "\n";
+  $original = file_get_contents($newUrl);
+  if ($original === false || file_put_contents($newUrl, $comment . $original) === false) {
+    return false;
+  }
+  $code = 0; // success — treat prepend as equivalent to sed exit code 0
 
   if( $code == 0 ) {
     return $newpath;

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<ruleset name="OpenML PHPMD Ruleset"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+    <description>
+        PHPMD ruleset for OpenML. Detects code smells, unused code, and naming issues.
+        Thresholds are relaxed to accommodate the existing legacy codebase.
+        Tighten these values gradually as the codebase is refactored.
+    </description>
+
+    <!-- Code size rules -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <!-- Legacy controllers (Api.php) are very large; start permissive -->
+            <property name="reportLevel" value="20"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="minimum" value="400"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="2000"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
+        <properties>
+            <property name="minimum" value="12"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount">
+        <properties>
+            <property name="minimum" value="60"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/TooManyFields">
+        <properties>
+            <property name="maxfields" value="20"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="40"/>
+        </properties>
+    </rule>
+
+    <!-- Unused code rules -->
+    <rule ref="rulesets/unusedcode.xml"/>
+
+    <!-- Naming rules -->
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <!-- Allow common short vars like $id, $db -->
+            <property name="minimum" value="2"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/LongVariable">
+        <properties>
+            <property name="maximum" value="40"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/ShortMethodName"/>
+    <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
+    <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+    <rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
+
+</ruleset>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="8"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedVariablesAndParams="false"
+    findUnusedCode="false"
+>
+    <!--
+        errorLevel 8 = most permissive (fewest errors reported).
+        Gradually lower this value (toward 1) as issues are fixed.
+        See: https://psalm.dev/docs/running_psalm/error_levels/
+    -->
+
+    <projectFiles>
+        <directory name="openml_OS"/>
+        <ignoreFiles>
+            <directory name="openml_OS/libraries"/>
+            <directory name="openml_OS/third_party"/>
+            <directory name="openml_OS/vendor"/>
+            <directory name="openml_OS/cache"/>
+            <directory name="openml_OS/logs"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <!-- Suppress issues common in CodeIgniter 3 magic-property patterns -->
+        <UndefinedMagicPropertyFetch errorLevel="suppress"/>
+        <UndefinedMagicPropertyAssignment errorLevel="suppress"/>
+        <UndefinedMagicMethod errorLevel="suppress"/>
+        <MixedAssignment errorLevel="suppress"/>
+        <MixedReturnStatement errorLevel="suppress"/>
+        <MixedMethodCall errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
## Summary

Fixes two command-injection vulnerabilities identified in #1265 where user-controlled values were interpolated into shell commands without escaping.

## Changes

### [openml_OS/helpers/api_helper.php](cci:7://file:///c:/Users/ma516/OneDrive/Desktop/openml%20repo/openml_OS/helpers/api_helper.php:0:0-0:0)

**[validate_arff()](cci:1://file:///c:/Users/ma516/OneDrive/Desktop/openml%20repo/openml_OS/helpers/api_helper.php:165:0-204:1)** — replaced `sed` shell command with pure PHP file I/O

The previous code built a `sed` command using `$name` (dataset name from user upload), which could contain shell metacharacters like `'`, `;`, `$`, etc.:

```php
// BEFORE — vulnerable
$command2 = "sed -i -e '$string' $newUrl";
exec(CMD_PREFIX . $command2, $res, $code);