### PR TITLE
fix: add validation for empty dataset name

### DIFF
--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -1186,6 +1186,10 @@ class Api_data extends MY_Api_Model {
 
     // obtain some other fields
     $name = '' . $xml->children('oml', true)->{'name'};
+    if (empty(trim($name))) {
+    $this->returnError(135, $this->version, $this->openmlGeneralErrorCode, "Dataset name is required");
+    return;
+}
     $version = $this->Dataset->incrementVersionNumber($name);
 
     //check and register the data files, return url


### PR DESCRIPTION
## Fix: Missing error message on blank dataset name (#1191)

### Problem

Currently, it is possible to upload a dataset without providing a name. Since the dataset name is a mandatory field, this leads to invalid dataset entries.

### Solution

Added validation in the `data_upload()` function to check if the dataset name is empty using `empty(trim($name))`.

### Changes

* Added validation for dataset name
* Returns API error when dataset name is missing

### Expected Behavior

* Empty dataset name → error is returned
* Valid dataset name → upload proceeds normally

### Notes

This ensures backend validation even if frontend validation is bypassed.
