### PR TITLE
fix: prevent duplicate dataset uploads using file_id check

### DIFF
--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -1276,6 +1276,18 @@ class Api_data extends MY_Api_Model {
     /* * * *
      * THE ACTUAL INSERTION
      * * * */
+    // 🔍 Check for duplicate dataset using file_id
+    // 🔍 Check for duplicate dataset using file_id
+    $existing = $this->Dataset->getWhereSingle('file_id = ' . $file_id);
+    if ($existing != false) {
+      $this->returnError(
+        135,
+        $this->version,
+        $this->openmlGeneralErrorCode,
+        "Dataset with same file already exists"
+      );
+      return;
+    }
     $id = $this->Dataset->insert($dataset);
     if (!$id) {
       $this->returnError(134, $this->version);


### PR DESCRIPTION
## Fix: Prevent duplicate dataset uploads (#1192)

Closes #1192

### Problem

Currently, the same dataset can be uploaded multiple times, resulting in duplicate entries with different dataset IDs. This leads to redundancy and inconsistency in the dataset repository.

### Solution

This PR introduces a duplicate check in the `data_upload()` method before inserting a new dataset.

* It checks if a dataset with the same `file_id` already exists.
* If a match is found, the upload is rejected with an appropriate error message.
* Otherwise, the dataset insertion proceeds as usual.

### Why this approach

The system already assigns a unique `file_id` to each uploaded dataset file, making it a reliable identifier for detecting duplicate uploads. This avoids the need for additional hashing or database schema changes.

### Result

* Prevents duplicate dataset uploads
* Ensures data consistency
* Keeps implementation minimal and aligned with existing codebase

### Note

This approach detects duplicates based on identical file uploads. Further enhancements (e.g., content-based hashing) can be explored if needed.
