### PR TITLE
fix: return 404 instead of 412 when dataset not found (#1176)

### DIFF
--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -792,7 +792,7 @@ class Api_data extends MY_Api_Model {
 
     $dataset = $this->Dataset->getById( $data_id );
     if( $dataset === false ) {
-      $this->returnError( 111, $this->version );
+      $this->returnError(111, $this->version, 404);
       return;
     }
 


### PR DESCRIPTION
Closes #1176

Problem
Currently, when requesting a dataset that does not exist, the API returns HTTP 412 (Precondition Failed). However, according to standard HTTP semantics, a missing resource should return 404 (Not Found).

Solution
Updated the dataset retrieval endpoint to return HTTP 404 when the dataset is not found.

Specifically:
- Modified the data($data_id) function in Api_data.php
- When $dataset === false, the response now uses:
  returnError(111, $this->version, 404)

Why this approach
- Keeps existing internal error code (111) unchanged
- Only updates HTTP response code for correctness
- Minimal and safe change without affecting other endpoints

Note
Other endpoints still use HTTP 412 for similar cases. This PR focuses on the main dataset retrieval endpoint. I can extend this behavior across other endpoints if desired.