### PR TITLE
Configurable Apache Workers and Status Page

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@ RUN docker-php-source extract \
 RUN apt update \
     && apt install -y --no-install-recommends openjdk-11-jre 
 
+ENV MAX_REQUEST_WORKERS=152
+
 COPY . /var/www/openml
 RUN mv /var/www/openml/openml_OS/config/BASE_CONFIG-BLANK.php /var/www/openml/openml_OS/config/BASE_CONFIG.php
 
@@ -20,6 +22,7 @@ COPY docker/config/*.load /etc/apache2/mods-enabled/
 COPY docker/config/api.conf /etc/apache2/sites-enabled/000-default.conf
 COPY docker/config/php.ini /usr/local/etc/php/
 COPY docker/config/.htaccess /var/www/openml/.htaccess
+COPY docker/config/mpm_prefork.conf /etc/apache2/mods-enabled/mpm_prefork.conf
 
 COPY docker/set_configuration.sh /scripts/
 

--- a/docker/config/.htaccess
+++ b/docker/config/.htaccess
@@ -1,3 +1,6 @@
+# The server-status path is reserved for the apache mod
+RewriteRule ^server-status$ - [L]
+
 RewriteEngine on
 
 # TODO: specific for main instance of OpenML site. Should do something better

--- a/docker/config/.htaccess
+++ b/docker/config/.htaccess
@@ -1,7 +1,7 @@
+RewriteEngine on
+
 # The server-status path is reserved for the apache mod
 RewriteRule ^server-status$ - [L]
-
-RewriteEngine on
 
 # TODO: specific for main instance of OpenML site. Should do something better
 RewriteCond %{HTTP_HOST} ^api_new.openml.org

--- a/docker/config/api.conf
+++ b/docker/config/api.conf
@@ -20,6 +20,11 @@ HostnameLookups Off
 	Require all granted
 </Directory>
 
+<Location "/server-status"> 
+    SetHandler server-status 
+    Require local 
+</Location>
+
 <VirtualHost *:80>
 	DocumentRoot /var/www/openml
 	RewriteEngine on

--- a/docker/config/mpm_prefork.conf
+++ b/docker/config/mpm_prefork.conf
@@ -1,0 +1,17 @@
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxRequestWorkers: maximum number of server processes allowed to start
+# MaxConnectionsPerChild: maximum number of requests a server process serves
+
+<IfModule mpm_prefork_module>
+        StartServers            5
+        MinSpareServers         5
+        MaxSpareServers         10
+        MaxRequestWorkers       ${MAX_REQUEST_WORKERS}
+        ServerLimit             ${MAX_REQUEST_WORKERS}
+        MaxConnectionsPerChild  0
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
 - Add the `server-status` page, available only from within the pod
 - Make the max workers configurable through an environment variable

I did not test the worker cap locally as such, but rather I installed the server-info mod locally which confirmed that the 152 was loaded. (default was 150)