### PR TITLE
Decrease the limit for limited list endpoints

### DIFF
--- a/openml_OS/models/api/v1/Api_evaluation.php
+++ b/openml_OS/models/api/v1/Api_evaluation.php
@@ -179,7 +179,7 @@ class Api_evaluation extends MY_Api_Model {
    *)
    */
   private function evaluation_list($segs, $user_id, $show_params) {
-    $result_limit = 10000;
+    $result_limit = 1000;
     $legal_filters = array('task', 'setup', 'flow', 'uploader', 'run', 'tag', 'limit', 'offset', 'function', 'per_fold', 'sort_order', 'study');
     list($query_string, $illegal_filters) = $this->parse_filters($segs, $legal_filters);
     if (count($illegal_filters) > 0) {

--- a/openml_OS/models/api/v1/Api_run.php
+++ b/openml_OS/models/api/v1/Api_run.php
@@ -271,7 +271,7 @@ class Api_run extends MY_Api_Model {
    *)
    */
   private function run_list($segs, $user_id) {
-    $result_limit = 10000;
+    $result_limit = 1000;
     $legal_filters = array('task', 'setup', 'flow', 'uploader', 'run', 'tag', 'limit', 'offset', 'task_type', 'study', 'show_errors');
     
     list($query_string, $illegal_filters) = $this->parse_filters($segs, $legal_filters);


### PR DESCRIPTION
Endpoints which already had a default/enforced limit reduced from 10k to 1k. This is hopefully only a temporary solution to reduce pressure on the database until we can figure out why it is slow.