### PR TITLE
Add error logging for silenced Elasticsearch exceptions

### DIFF
--- a/openml_OS/libraries/ElasticSearch.php
+++ b/openml_OS/libraries/ElasticSearch.php
@@ -331,7 +331,7 @@ class ElasticSearch {
                 return $this->$method_name($id, $altmetrics, $verbosity);
 	    } catch (Exception $e) {
 		echo $e->getMessage();
-                // TODO: log?
+                log_message('error', '[ElasticSearch] Indexing failed for type ' . $type . ' (id: ' . ($id ?: 'all') . '): ' . $e->getMessage());
             }
         } else {
             return 'No function exists to build index of type ' . $type;
@@ -352,7 +352,7 @@ class ElasticSearch {
                 return $this->$method_name(false, $id, $altmetrics, $verbosity);
 	    } catch (Exception $e) {
 		echo $e->getMessage();
-                // TODO: log?
+                log_message('error', '[ElasticSearch] Indexing from id failed for type ' . $type . ' (from id: ' . ($id ?: '0') . '): ' . $e->getMessage());
             }
         } else {
             return 'No function exists to build index of type ' . $type;

--- a/openml_OS/models/api/v1/Api_data.php
+++ b/openml_OS/models/api/v1/Api_data.php
@@ -1306,7 +1306,7 @@ class Api_data extends MY_Api_Model {
       // update counters
       $this->elasticsearch->index('user', $this->user_id);
     } catch (Exception $e) {
-      // TODO: should log
+      log_message('error', '[Api_data] ElasticSearch indexing failed for data id ' . $id . ': ' . $e->getMessage());
     }
 
     // insert tags. This relies on the ES record to exist.

--- a/openml_OS/models/api/v1/Api_flow.php
+++ b/openml_OS/models/api/v1/Api_flow.php
@@ -655,7 +655,7 @@ class Api_flow extends MY_Api_Model {
       // update counters
       $this->elasticsearch->index('user', $this->user_id);
     } catch (Exception $e) {
-      // TODO: should be logged
+      log_message('error', '[Api_flow] ElasticSearch indexing failed for flow id ' . $impl . ': ' . $e->getMessage());
     }
 
     $this->xmlContents( 'implementation-upload', $this->version, $implementation );
@@ -855,7 +855,7 @@ class Api_flow extends MY_Api_Model {
     try {
       $this->elasticsearch->index('flow', $flow_id);
     } catch (Exception $e) {
-      // TODO should be logged
+      log_message('error', '[Api_flow] ElasticSearch indexing failed for flow id ' . $flow_id . ': ' . $e->getMessage());
     }
 
 

--- a/openml_OS/models/api/v1/Api_run.php
+++ b/openml_OS/models/api/v1/Api_run.php
@@ -1022,7 +1022,7 @@ class Api_run extends MY_Api_Model {
     try {
       $this->elasticsearch->index('run', $runId);
     } catch (Exception $e) {
-      // TODO: should log
+      log_message('error', '[Api_run] ElasticSearch indexing failed for run id ' . $runId . ': ' . $e->getMessage());
     }
 
     $timestamps[] = microtime(true); // profiling 4

--- a/openml_OS/models/api/v1/Api_study.php
+++ b/openml_OS/models/api/v1/Api_study.php
@@ -210,7 +210,7 @@ class Api_study extends MY_Api_Model {
       // update counters
       $this->elasticsearch->index('user', $this->user_id);
     } catch (Exception $e) {
-      // TODO: should log
+      log_message('error', '[Api_study] ElasticSearch indexing failed for study id ' . $study_id . ': ' . $e->getMessage());
     }
     
     $this->xmlContents('study-upload', $this->version, array('study_id' => $study_id));


### PR DESCRIPTION
### Description
This PR resolves several maintainer TODOs by adding proper error logging to empty `catch` blocks that previously swallowed ElasticSearch exceptions silently.

**Changes made:**
- Replaced empty `catch` blocks in API models (`Api_data`, `Api_flow`, `Api_run`, `Api_study`) with `log_message('error', ...)` calls.
- Updated `ElasticSearch.php` to log exceptions alongside the existing `echo` statements.
- Each log entry includes a component tag (e.g., `[Api_data]`), the entity type/ID, and the exception message.

**Why this is needed:**
When ElasticSearch indexing fails during entity uploads, the errors were previously ignored, making production debugging difficult. Logging these via CodeIgniter's built-in `log_message` ensures failures are captured in the configured log path (e.g., `/var/www/openml/logs/`).

**Related Issues:**
Fixes #1297 
