### PR TITLE
Fix a bug where filesize was called for external datasets

### DIFF
--- a/openml_OS/models/data/v1/Data_server.php
+++ b/openml_OS/models/data/v1/Data_server.php
@@ -28,12 +28,23 @@ class Data_server extends CI_Model {
       return;
     }
 
-    // in case of externally linked file, handle alternativelly
+    // We can't quickly assess whether remote files exist and whether or not they
+    // have been modified, so we just "hope for the best" and redirect the client.
+    // Historically, remote files were always hosted by other parties, datasets uploaded
+    // to OpenML would be stored on disk. Since 2025ish we started migrating over these
+    // files from disk to our self-hosted MinIO server. To the PHP API, these are also
+    // considered "remote" files of the type 'url', so files that would meet this condition
+    // could be both something like "https://zenodo.org/..." but 
+    // also "https://data.openml.org/...". While MinIO can be probed for this data, we opted
+    // not to update the PHP API.
     if ($file->{'type'} == 'url') {
       header('Location: ' . $file->filepath);
       return;
     }
 
+    // Some files do not exist on MinIO and so are read from disk (a persistent k8s volume).
+    // This includes newly uploaded dataset and run files, as these are first written to disk
+    // by the PHP API. 
     if (!file_exists(DATA_PATH . $file->filepath)) {
       $this->_error404();
       return;

--- a/openml_OS/models/data/v1/Data_server.php
+++ b/openml_OS/models/data/v1/Data_server.php
@@ -28,24 +28,25 @@ class Data_server extends CI_Model {
       return;
     }
 
-    if (!file_exists(DATA_PATH . $file->filepath) && $file->type != 'url') {
+    // in case of externally linked file, handle alternativelly
+    if ($file->{'type'} == 'url') {
+      header('Location: ' . $file->filepath);
+      return;
+    }
+
+    if (!file_exists(DATA_PATH . $file->filepath)) {
       $this->_error404();
       return;
     }
     
-    if (filesize(DATA_PATH . $file->filepath) != $file->filesize && $file->type != 'url') {
+    if (filesize(DATA_PATH . $file->filepath) != $file->filesize) {
       $this->_email_filesize_error($file);
       $this->_error404();
       return;
     }
 
-    // in case of externally linked file, handle alternativelly
-    if ($file->{'type'} == 'url') {
-      header('Location: ' . $file->filepath);
-    } else {
-      $this->_header_download($file->filename_original, $file->filesize, $file->extension, $file->mime_type);
-      readfile_chunked(DATA_PATH . $file->filepath);
-    }
+    $this->_header_download($file->filename_original, $file->filesize, $file->extension, $file->mime_type);
+    readfile_chunked(DATA_PATH . $file->filepath);
   }
 
   function view($id, $name = 'undefined') {


### PR DESCRIPTION
Especially now that runs and datasets are hosted "externally" on MinIO, there was a lot of erroneous `filesize` attempts:
```
ERROR - 2026-07-29 09:35:43 --> Severity: Warning --> filesize(): stat failed for /var/www/data/https://data.openml.org/runs/0000/0000/0092/0988/run8425768915260009867.xml /var/www/openml/openml_OS/models/data/v1/Data_server.php 36
```
This stemmed from the filesize being called even though the dataset might be hosted externally. We simply re-order the clauses so that an "external" dataset correctly redirects immediately.