### PR TITLE
Whitelist specific functions for the data controller

### DIFF
--- a/openml_OS/controllers/Data.php
+++ b/openml_OS/controllers/Data.php
@@ -54,6 +54,26 @@ class Data extends CI_Controller {
     $controller = array_shift($segs);
     $this->version = array_shift($segs);
     $function = array_shift($segs);
+
+    $function_whitelist = array('download', 'view', 'get_csv');
+
+    if (!in_array($function, $function_whitelist)) {
+      http_response_code(404);
+      echo 'Function not valid.';
+      return;
+    }
+
+    if (!$segs) {
+      http_response_code(400);
+      echo 'Missing value for argument id.';
+      return;
+    }
+
+    if (count($segs) > 2) {
+      http_response_code(400);
+      echo 'Expected at most two arguments: id (required) and name (optional).';
+      return;
+    }
     
     call_user_func_array(array($this->Data_server, $function), $segs);
   }


### PR DESCRIPTION
The controller would allow attempts at calling arbitrary functions. This is harmless as long as no new functions get defined on the class - the exposed functions are exactly those we want to allow. However, we noticed from logs that there are attempts at calling other functions, so we are taking preventative measures to close things down so that:

 - should, for some reason, a new function get added to the old data controller, it cannot be accidentally exposed
 - invalid access to functions that don't exist don't result in a PHP error, but rather in a normal response to the client
 
 This patch introduces a whitelist of functions which are allowed to be called this way, and provides clearer error messages if an unknown function is called, or a known function is called incorrectly.

-- 

I considered using the standard `returnError` defined on `MY_Api_Model` but you would need to load in those modules and hack around it not actually being called from the new controller:

Anywhere in the path (e.g., in the constructor, or specifically only when an error is actually raised):
```diff
+   $this->load->Model('api/v1/Api_study');  // Any controller that extends MY_Api_Model
+    $this->load->model('Log');
+    $this->load->view('pages/api_new/v1/xml/pre.php');
```
and then at the call site:
```diff
+      $this->controller = 'api_new';
+      $this->page = 'xml';
+      $this->Api_study->returnError(100, $this->Api_study->version);
```
because at some point the error template path is determined by interpolation of the controller and page.

I figured it's better to keep things simple.