### PR TITLE
Remove type parameter

### DIFF
--- a/openml_OS/controllers/Api_new.php
+++ b/openml_OS/controllers/Api_new.php
@@ -117,7 +117,7 @@ class Api_new extends CI_Controller {
     $this->_show_webpage();
   }
 
-  public function v1($type) {
+  public function v1(...$args) {
     $this->bootstrap('1');
   }
 

--- a/openml_OS/controllers/Data.php
+++ b/openml_OS/controllers/Data.php
@@ -39,7 +39,7 @@ class Data extends CI_Controller {
     }
   }
   
-  public function v1($type) {
+  public function v1(...$args) {
     $this->load->Model('data/v1/Data_server');
     $this->bootstrap('1');
   }


### PR DESCRIPTION
Stacked on #1304.

Allows arbitrary number of arguments to v1 functions, as this function is called by Code Igniter and the values passed depends on how the function is accessed. The values are never actually used, so we could also omit them, but that would raise errors if we were to ever update to PHP 8+.

When deployed with the `services` docker compose making a request `curl http://localhost:8080/data/v1` used to write an error `Severity: error --> Exception: Too few arguments to function Data::v1(), 0 passed in /var/www/openml/system/core/CodeIgniter.php on line 532 and exactly 1 expected /var/www/openml/openml_OS/controllers/Data.php 42` and return XML about an PHP error being encountered, and now instead returns an error to the client with "Function not valid".