### PR TITLE
Avoid indexing to an empty/null array and log the attempt

### DIFF
--- a/openml_OS/models/Task_type_inout.php
+++ b/openml_OS/models/Task_type_inout.php
@@ -50,7 +50,7 @@ class Task_type_inout extends MY_Database_Read_Model {
       $additional = $this->query($sql);
 
       if (empty($additional)) {
-        log_message('error', 'empty result set for query \'' . $sql . '\' for task ' . (string)$task_id);
+        log_message('debug', 'empty result set for query \'' . $sql . '\' for task ' . (string)$task_id);
         continue;
       }
       

--- a/openml_OS/models/Task_type_inout.php
+++ b/openml_OS/models/Task_type_inout.php
@@ -48,6 +48,11 @@ class Task_type_inout extends MY_Database_Read_Model {
     foreach ($tables as $table => $dummy_var) {
       $sql = 'SELECT * FROM `'.$table.'` WHERE `id` = "'.$values[$table].'";';
       $additional = $this->query($sql);
+
+      if (empty($additional)) {
+        log_message('error', 'empty result set for query \'' . $sql . '\' for task ' . (string)$task_id);
+        continue;
+      }
       
       foreach ($additional[0] as $key => $value) {
         $values[$table.'.'.$key] = $value;


### PR DESCRIPTION
This patch addresses both the immediate issue of invalid values being provided to the `foreach` function, but also adds some logging so that we can identify the offending tasks and inspect the template content.

--

Some unknown request is generating the following error:
```
 Severity: Warning --> Invalid argument supplied for foreach() /var/www/openml/openml_OS/models/Task_type_inout.php 52
```
This seems to be the result of the `$additional` being NULL or empty, which raises this issue in PHP 7 when it is provided as an argument to `foreach`. My understanding is that this _should_ not happen, as the inclusion in the template indicates some data is expected. The indexing `additional[0]` seems to support this idea. 

While from the code it is clear this happens on access to _some_ task, cross referencing the logs we cannot find the matching server requests which produces this error. The new log message should allow us to investigate.

