### PR TITLE
Surpress warning if file is not found in `get_csv`

### DIFF
--- a/openml_OS/models/data/v1/Data_server.php
+++ b/openml_OS/models/data/v1/Data_server.php
@@ -109,7 +109,17 @@ class Data_server extends CI_Model {
       $location = $file->filepath;
     }
 
-    $handle = fopen($location, 'r');
+    $handle = @fopen($location, 'r');
+
+    if (!$handle) {
+      log_message('debug', "Failed to read file " . (string)$id . " from '" . $location . "'");
+      $this->_error404();
+      return;
+    }
+
+    // Read the ARFF header -- everything before the @data marker. 
+    // The header data is discarded. 
+    // Our CSV only provides feature names which are queried from the database later.
     $position = -1;
     for ($i = 0; ($line = fgets($handle)) !== false; ++$i) {
       // process the line read.
@@ -121,6 +131,7 @@ class Data_server extends CI_Model {
 
     if ($position < 0) { # apparently we didn't find '@data'
       # TODO: more meaningfull error
+      log_message('debug', "Could not covert file " . (string)$id . " in '" . $location . "': no @data marker present.");
       $this->_error404();
       return;
     }
@@ -131,6 +142,7 @@ class Data_server extends CI_Model {
     $features = $this->Data_feature->getColumnWhere('name', 'did = "' . $dataset->did . '"', 'index ASC');
     if ($features < 2) {
       # TODO: more meaningfull error
+      log_message('debug', "Not enough features present for dataset " . $dataset->did . " aborting conversion to CSV.");
       $this->_error404();
       return;
     }


### PR DESCRIPTION
This avoids a PHP warning being raised due to `fopen` being called with an inaccessible location.
Instead, we log a more meaningful message on failure so we can investigate these cases. I also added some logging for other failure modes since they likely point to bad data.

If the PHP API is running in `production` mode (in `index.php`) then the observable behavior is the same: a 404 response with a 404 HTML webpage. The only change is the logged message. If it is running in `development`, then the API used to return the PHP warning to the client but now no longer does so.